### PR TITLE
Use :request-method key to pull out HTTP method

### DIFF
--- a/src/corax/core.clj
+++ b/src/corax/core.clj
@@ -74,7 +74,7 @@
   ([req]
      (http {} req))
   ([event req]
-     {:pre [(some? (:method req))
+     {:pre [(some? (:request-method req))
             (some? (:scheme req))
             (some? (:server-name req))
             (some? (:server-port req))

--- a/src/corax/http.clj
+++ b/src/corax/http.clj
@@ -6,10 +6,11 @@
     (str (name scheme) "://" server-name port-str uri)))
 
 (defn build-http-info
-  [{:keys [headers method params query-string remote-addr] :as req} & [env]]
+  [{:keys [headers request-method params query-string remote-addr] :as req}
+   & [env]]
   {:data params
    :env (merge {:REMOTE_ADDR remote-addr} env)
    :headers headers
-   :method method
+   :method (-> request-method name .toUpperCase)
    :query_string query-string
    :url (build-url req)})

--- a/test/corax/core_test.clj
+++ b/test/corax/core_test.clj
@@ -64,7 +64,7 @@
             "should merge data maps")))))
 
 (deftest test-http
-  (let [req {:method :post
+  (let [req {:request-method :post
              :scheme :http
              :server-name "example.com"
              :server-port 12345

--- a/test/corax/http_test.clj
+++ b/test/corax/http_test.clj
@@ -4,6 +4,7 @@
 
 (def default-request
   {:remote-addr "127.0.0.1"
+   :request-method :get
    :scheme :http
    :server-name "example.com"
    :server-port 80
@@ -23,6 +24,10 @@
            "http://example.com"))))
 
 (deftest test-build-http-info
+  (testing "method"
+    (let [http-info (build-http-info default-request)]
+      (is (= (:method http-info) "GET"))))
+
   (testing ":env"
     (testing "with no env map"
       (let [http-info (build-http-info default-request)]


### PR DESCRIPTION
We used the wrong key, :method, to lookup the HTTP request method from
the ring request. This forced callers to remap :request-method ->
:method in their ring requests, because we were asserting that :method
was present in the request.

We now look for :request-method. We also turn the keyword to an upper
case string in http.clj.

Fixes #2
