### PR TITLE
Check HTTP response status code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :scm {:name "git"
         :url "https://github.com/liwp/corax"}
   :deploy-repositories [["releases" :clojars]]
-  :dependencies [[clj-stacktrace "0.2.8"]
+  :dependencies [[cheshire "5.3.1"]
+                 [clj-stacktrace "0.2.8"]
                  [org.clojure/clojure "1.6.0"]
                  [raven-clj "1.1.0"]])

--- a/src/corax/error_reporter.clj
+++ b/src/corax/error_reporter.clj
@@ -1,27 +1,38 @@
 (ns corax.error-reporter
-  (:require [clj-stacktrace.repl :refer [pst-str]]
+  (:require [cheshire.core :as json]
+            [clj-stacktrace.repl :refer [pst-str]]
             [clojure.pprint :refer [pprint]]
             [raven-clj.core :as raven]))
 
 (def ^:const error-messages
-  {:no-dsn "A sentry DSN was not provided. Cannot report event."
-   :exception "Unexpected exception."})
+  {:exception "Unexpected exception."
+   :http-status "Unexpected HTTP status."
+   :no-dsn "A sentry DSN was not provided. Cannot report event."
+   })
 
 (defn- default-log-fn
-  [{:keys [error event exception]}]
+  [{:keys [error event exception response]}]
   (let [event-str (with-out-str (pprint event))
         message (get error-messages error (str "Unknown error: " error))]
     (println message)
     (when exception
       (println (pst-str exception)))
+    (when response
+      (pprint response))
     (println "Event:" event-str)))
 
 (defn- handle-event
   [event dsn log-fn]
   (try
-    (raven/capture dsn event)
+    (let [rsp (raven/capture dsn event)]
+      (if (= (:status rsp) 200)
+        (-> rsp :body (json/parse-string true) :id)
+        (do
+          (log-fn {:error :http-status :response rsp :event event})
+          nil)))
     (catch Throwable e
-      (log-fn {:error :exception :exception e :event event}))))
+      (log-fn {:error :exception :exception e :event event})
+      nil)))
 
 (defn report
   [event dsn log-fn]


### PR DESCRIPTION
We used to just pass through the raven-clj http request response without
checking for success. We now check for status == 200 (Sentry seems to
return 200 for success and 400 for errors), and we parse Sentry's error
report ID from the response. The caller should probably print out the ID
to make it easier to correlate logs and error reports.

Fixes #5
