### PR TITLE
Capture individual exceptions

### DIFF
--- a/src/corax/error_reporter.clj
+++ b/src/corax/error_reporter.clj
@@ -2,19 +2,23 @@
   (:require [cheshire.core :as json]
             [clj-stacktrace.repl :refer [pst-str]]
             [clojure.pprint :refer [pprint]]
-            [raven-clj.core :as raven]))
+            [raven-clj.core :as raven])
+  (:import [com.fasterxml.jackson.core JsonGenerationException]))
 
 (def ^:const error-messages
   {:exception "Unexpected exception."
    :http-status "Unexpected HTTP status."
-   :no-dsn "A sentry DSN was not provided. Cannot report event."
-   })
+   :invalid-dsn "DSN parsing failed."
+   :invalid-payload "Event cannot be serialized to JSON."
+   :no-dsn "A sentry DSN was not provided. Cannot report event."})
 
 (defn- default-log-fn
-  [{:keys [error event exception response]}]
+  [{:keys [dsn error event exception response]}]
   (let [event-str (with-out-str (pprint event))
         message (get error-messages error (str "Unknown error: " error))]
     (println message)
+    (when dsn
+      (println "DSN: " dsn))
     (when exception
       (println (pst-str exception)))
     (when response
@@ -30,6 +34,12 @@
         (do
           (log-fn {:error :http-status :response rsp :event event})
           nil)))
+    (catch NullPointerException e
+      (log-fn {:error :invalid-dsn :dsn dsn :event event})
+      nil)
+    (catch JsonGenerationException e
+      (log-fn {:error :invalid-payload :exception e :event event})
+      nil)
     (catch Throwable e
       (log-fn {:error :exception :exception e :event event})
       nil)))

--- a/test/corax/error_reporter_test.clj
+++ b/test/corax/error_reporter_test.clj
@@ -1,30 +1,23 @@
 (ns corax.error-reporter-test
   (:require [corax.error-reporter :as err]
             [clojure.test :refer :all]
-            [raven-clj.core :as raven]))
+            [raven-clj.core :as raven])
+  (:import [com.fasterxml.jackson.core JsonGenerationException]))
 
 (deftest test-default-log-fn
   (testing "default-log-fn"
-    (testing "with exception"
-      (let [ex (Exception. "dummy error")]
-        (let [s (with-out-str
-                  (#'err/default-log-fn {:error :exception
-                                         :exception ex
-                                         :event :mock-event}))]
-          (is (.contains s (:exception err/error-messages))
-              "should print out message")
-          (is (.contains s "dummy error") "should print out exception")
-          (is (.contains s ":mock-event") "should print out event"))))
-
-    (testing "with missing DSN"
-      (let [s (with-out-str
-                (#'err/default-log-fn {:error :no-dsn
+    (testing "with :exception"
+      (let [ex (Exception. "dummy error")
+            s (with-out-str
+                (#'err/default-log-fn {:error :exception
+                                       :exception ex
                                        :event :mock-event}))]
-        (is (.contains s (:no-dsn err/error-messages))
+        (is (.contains s (:exception err/error-messages))
             "should print out message")
+        (is (.contains s "dummy error") "should print out exception")
         (is (.contains s ":mock-event") "should print out event")))
 
-    (testing "with invalid HTTP status code"
+    (testing "with :http-status"
       (let [s (with-out-str
                 (#'err/default-log-fn {:error :http-status
                                        :response :mock-http-response
@@ -34,10 +27,39 @@
         (is (.contains s ":mock-http-response") "should print out response")
         (is (.contains s ":mock-event") "should print out event")))
 
+    (testing "with :invalid-dsn"
+      (let [s (with-out-str
+                (#'err/default-log-fn {:error :invalid-dsn
+                                       :dsn :mock-dsn
+                                       :event :mock-event}))]
+        (is (.contains s (:invalid-dsn err/error-messages))
+            "should print out message")
+        (is (.contains s ":mock-dsn") "should print out DSN")
+        (is (.contains s ":mock-event") "should print out event")))
+
+    (testing "with :invalid-payload"
+      (let [ex (JsonGenerationException. "JSON generation error")
+            s (with-out-str
+                (#'err/default-log-fn {:error :invalid-payload
+                                       :exception ex
+                                       :event :mock-event}))]
+        (is (.contains s (:invalid-payload err/error-messages))
+            "should print out message")
+        (is (.contains s "JSON generation error") "should print out exception")
+        (is (.contains s ":mock-event") "should print out event")))
+
+    (testing "with :no-dsn"
+      (let [s (with-out-str
+                (#'err/default-log-fn {:error :no-dsn
+                                       :event :mock-event}))]
+        (is (.contains s (:no-dsn err/error-messages))
+            "should print out message")
+        (is (.contains s ":mock-event") "should print out event")))
+
     (testing "with unknown error"
       (let [s (with-out-str
                 (#'err/default-log-fn {:error :unknown-error
-                                              :event {:my :event}}))]
+                                       :event {:my :event}}))]
         (is (.contains s "Unknown error: :unknown-error")
             "should print out message")
         (is (.contains s "{:my :event}") "should print out event")))))
@@ -45,39 +67,71 @@
 (deftest test-handle-event
   (testing "handle-event"
     (testing "with success"
-      (let [capture-called (atom nil)]
-        (with-redefs [raven/capture
-                      (fn [dsn event]
-                        (reset! capture-called true)
-                        (is (= dsn "dummy dsn"))
-                        (is (= event {}))
-                        {:status 200
-                         :body "{\"id\":\"711a050314874ff08e18d14b27a2dbec\"}"})]
-          (let [report-id (#'err/handle-event {} "dummy dsn" (fn [& args]))]
-            (is (true? @capture-called) "should call capture")
-            (is (= report-id "711a050314874ff08e18d14b27a2dbec"))))))
+      (with-redefs [raven/capture
+                    (fn [dsn event]
+                      (is (= dsn :mock-dsn))
+                      (is (= event :mock-event))
+                      {:status 200
+                       :body "{\"id\":\"711a0503...\"}"})]
+        (let [report-id (#'err/handle-event :mock-event :mock-dsn (fn [& _]))]
+          (is (= report-id "711a0503...")))))
 
     (testing "with unexpected HTTP status code"
       (let [log-fn-called (atom nil)
             log-fn (fn [{:keys [error response event]}]
                      (reset! log-fn-called true)
                      (is (= response {:status 400}))
-                     (is (= event {})))]
+                     (is (= event :mock-event)))]
         (with-redefs [raven/capture (fn [dsn event]
+                                      (is (= dsn :mock-dsn))
+                                      (is (= event :mock-event))
                                       {:status 400})]
-          (let [report-id (#'err/handle-event {} "dummy dsn" log-fn)]
+          (let [report-id (#'err/handle-event :mock-event :mock-dsn log-fn)]
             (is (true? @log-fn-called) "should call log-fn")
             (is (nil? report-id))))))
 
-    (testing "with exception"
+    (testing "with NPE (caused by a DSN parse error)"
+      (let [ex (NullPointerException. "DSN parse error")
+            log-fn-called (atom nil)
+            log-fn (fn [{:keys [error exception event]}]
+                     (reset! log-fn-called true)
+                     (is (= error :invalid-dsn))
+                     (is (= event :mock-event)))]
+        (with-redefs [raven/capture (fn [dsn event]
+                                      (is (= dsn :mock-dsn))
+                                      (is (= event :mock-event))
+                                      (throw ex))]
+          (let [report-id (#'err/handle-event :mock-event :mock-dsn log-fn)]
+            (is (true? @log-fn-called) "should call log-fn")
+            (is (nil? report-id))))))
+
+    (testing "with JSON generation error"
+      (let [ex (JsonGenerationException. "JSON generation error")
+            log-fn-called (atom nil)
+            log-fn (fn [{:keys [error exception event]}]
+                     (reset! log-fn-called true)
+                     (is (= error :invalid-payload))
+                     (is (= event :mock-event)))]
+        (with-redefs [raven/capture (fn [dsn event]
+                                      (is (= dsn :mock-dsn))
+                                      (is (= event :mock-event))
+                                      (throw ex))]
+          (let [report-id (#'err/handle-event :mock-event :mock-dsn log-fn)]
+            (is (true? @log-fn-called) "should call log-fn")
+            (is (nil? report-id))))))
+
+    (testing "with unexpected exception"
       (let [ex (Exception. "dummy error")
             log-fn-called (atom nil)
             log-fn (fn [{:keys [error exception event]}]
                      (reset! log-fn-called true)
                      (is (= error :exception))
-                     (is (= event {})))]
-        (with-redefs [raven/capture (fn [dsn event] (throw ex))]
-          (let [report-id (#'err/handle-event {} "dummy dsn" log-fn)]
+                     (is (= event :mock-event)))]
+        (with-redefs [raven/capture (fn [dsn event]
+                                      (is (= dsn :mock-dsn))
+                                      (is (= event :mock-event))
+                                      (throw ex))]
+          (let [report-id (#'err/handle-event :mock-event :mock-dsn log-fn)]
             (is (true? @log-fn-called) "should call log-fn")
             (is (nil? report-id))))))))
 


### PR DESCRIPTION
Instead of capturing just Throwable, we now capture also NPEs and
JsonGenerationExceptions. The former should only be caused by the DSN
being of an incorrect format to the parsing fails, and the latter is
caused when raven-clj tries to serialize the event to JSON and some
fields are not serializable.

Fixes #6
