### PR TITLE
Provide ring middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: clojure
 lein: lein2
 
+script: lein2 ci
+
 jdk:
   - openjdk7
   - oraclejdk7

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,14 @@
   :dependencies [[cheshire "5.3.1"]
                  [clj-stacktrace "0.2.8"]
                  [org.clojure/clojure "1.6.0"]
-                 [raven-clj "1.1.0"]])
+                 [raven-clj "1.1.0"]]
+
+  :profiles {:dev {:dependencies [[ring-mock "0.1.5"]]
+
+                   :plugins [[jonase/eastwood "0.1.4"]
+                             [listora/whitespace-linter "0.1.0"]]
+
+                   :eastwood {:exclude-linters [:deprecations :unused-ret-vals]}
+
+                   :aliases {"ci" ["do" ["test"] ["lint"]]
+                             "lint" ["do" ["whitespace-linter"] ["eastwood"]]}}})

--- a/src/corax/middleware.clj
+++ b/src/corax/middleware.clj
@@ -1,0 +1,29 @@
+(ns corax.middleware
+  (:require [corax.core :as err]))
+
+(defn- report-error
+  [request exception opts]
+  (-> (err/exception exception)
+      (err/http request)
+      (err/report opts)))
+
+(defn wrap-exception-reporting
+  "Report any request handling exceptions to Sentry.
+
+  `opts` is an options map with :dsn and :log-fn keys. :dsn is
+  mandatory, and it is used to specify the Sentry DSN. :log-fn is
+  optional and is used to override the default Corax logger (see
+  corax.core/report for more details).
+
+  Note: this middleware will not produce a ring response when an error
+  occurs. Instead it will rethrow the original exception. The
+  application should wrap another ring middleware around this one,
+  which will catch all exceptions and return ring responses
+  with :status 500."
+  [handler {:keys [dsn log-fn] :as opts}]
+  (fn [req]
+    (try
+      (handler req)
+      (catch Throwable e
+        (report-error req e opts)
+        (throw e)))))

--- a/test/corax/middleware_test.clj
+++ b/test/corax/middleware_test.clj
@@ -1,0 +1,27 @@
+(ns corax.middleware-test
+  (:require [corax.core :as err]
+            [corax.middleware :refer :all]
+            [clojure.test :refer :all]
+            [ring.mock.request :as mock]))
+
+(deftest test-wrap-exception-reporting
+  (testing "wrap-exception-reporting"
+    (let [ex (Exception. "error")
+          handler (wrap-exception-reporting
+                   (fn [req] (throw ex))
+                   {:dsn :mock-dsn
+                    :log-fn :mock-log-fn})
+          report-called (atom nil)]
+      (with-redefs [err/report
+                    (fn [event {:keys [dsn log-fn]}]
+                      (reset! report-called true)
+                      (is (= (-> event :message) "error"))
+                      (is (some? (:exception event)))
+                      (is (some? (:sentry.interfaces.Http event)))
+                      (is (= (-> event :sentry.interfaces.Http :method) "GET"))
+                      (is (= dsn :mock-dsn))
+                      (is (= log-fn :mock-log-fn)))]
+        (is (thrown-with-msg?
+             Exception #"error"
+             (handler (mock/request :get "/"))))
+        (is (true? @report-called))))))


### PR DESCRIPTION
Implement ring middleware for reporting exceptions.

Modify the travis-ci build to run linters as well.
